### PR TITLE
Fix za tokene i MenuItems

### DIFF
--- a/Data/GozbaDbContext.cs
+++ b/Data/GozbaDbContext.cs
@@ -165,37 +165,37 @@ namespace gozba_na_klik.Data
 
 
             #region SEED DATA
-            modelBuilder.Entity<User>().HasData(
-                new User
-                {
-                    Id = 1,
-                    FirstName = "Admin",
-                    LastName = "One",
-                    Username = "Admin1",
-                    Email = "admin1@gozba.com",
-                    PasswordHash = "$2a$11$VdTkF.NE1aw8uZmfFO51OuxlW9qrvbx7W8g3iKw6aHcuC1vHfMJt6\r\n",
-                    Role = Role.Admin
-                },
-                new User
-                {
-                    Id = 2,
-                    FirstName = "Admin",
-                    LastName = "Two",
-                    Username = "Admin2",
-                    Email = "admin2@gozba.com",
-                    PasswordHash = "$2a$11$VdTkF.NE1aw8uZmfFO51OuxlW9qrvbx7W8g3iKw6aHcuC1vHfMJt6\r\n",
-                    Role = Role.Admin
-                },
-                new User
-                {
-                    Id = 3,
-                    FirstName = "Admin",
-                    LastName = "Three",
-                    Username = "Admin3",
-                    Email = "admin3@gozba.com",
-                    PasswordHash = "$2a$11$VdTkF.NE1aw8uZmfFO51OuxlW9qrvbx7W8g3iKw6aHcuC1vHfMJt6\r\n",
-                    Role = Role.Admin
-                });
+            //modelBuilder.Entity<User>().HasData(
+            //    new User
+            //    {
+            //        Id = 1,
+            //        FirstName = "Admin",
+            //        LastName = "One",
+            //        Username = "Admin1",
+            //        Email = "admin1@gozba.com",
+            //        PasswordHash = "$2a$11$VdTkF.NE1aw8uZmfFO51OuxlW9qrvbx7W8g3iKw6aHcuC1vHfMJt6\r\n",
+            //        Role = Role.Admin
+            //    },
+            //    new User
+            //    {
+            //        Id = 2,
+            //        FirstName = "Admin",
+            //        LastName = "Two",
+            //        Username = "Admin2",
+            //        Email = "admin2@gozba.com",
+            //        PasswordHash = "$2a$11$VdTkF.NE1aw8uZmfFO51OuxlW9qrvbx7W8g3iKw6aHcuC1vHfMJt6\r\n",
+            //        Role = Role.Admin
+            //    },
+            //    new User
+            //    {
+            //        Id = 3,
+            //        FirstName = "Admin",
+            //        LastName = "Three",
+            //        Username = "Admin3",
+            //        Email = "admin3@gozba.com",
+            //        PasswordHash = "$2a$11$VdTkF.NE1aw8uZmfFO51OuxlW9qrvbx7W8g3iKw6aHcuC1vHfMJt6\r\n",
+            //        Role = Role.Admin
+            //    });
 
             modelBuilder.Entity<Allergen>().HasData(
                 new Allergen { Id = 1, Name = "Gluten" },

--- a/Service/AuthService.cs
+++ b/Service/AuthService.cs
@@ -23,18 +23,23 @@ namespace gozba_na_klik.Service
 
         public async Task<UserDto?> LoginAsync(LoginDto dto)
         {
-            var user = await _userRepo.GetByEmailAsync(dto.Email);
+            var email = (dto.Email ?? "").Trim().ToLowerInvariant();
+            //pronalazenje user-a po email-u
+            var user = await _userRepo.GetByEmailAsync(email);
 
-            //VALIDACIJA ZA PASSWORD OVDE IDE
+            if (user == null)
+                return null;
+            //proveravanje sifre
+            var isValid = BCrypt.Net.BCrypt.Verify(dto.Password, user.PasswordHash);
+            if (!isValid)
+                return null;
+            //mapiranje u DTO i vracanje
             var userDto = _mapper.Map<UserDto>(user);
-
-            return user is null ? null : userDto;
+            return userDto;
         }
         public async Task<User?> GetByEmailAsync(string email)
         {
-            var user = await _userRepo.GetByEmailAsync(email);
-
-            return null;
+            return await _userRepo.GetByEmailAsync(email);
         }
         public async Task<User?> RegisterUserAsync(User u)
         {


### PR DESCRIPTION
- Sredjen login flow za sve role: login vraca token + user, a front salje Bearer token automatski.
- Ociscen seed za stare admine i ubaceni novi test useri po rolama.
- Resen crash na restoran rutama: EF je trazio "MenuItems", a u bazi je bila stara "MenuItem".
  Preimenovana tabela/index u Postgresu da se schema poklopi sa modelom.
- Posle ovoga /api/customer/restaurants i /api/owner/restaurants vise ne vracaju 500.
