### PR TITLE
Auth: account activation and password reset flow

### DIFF
--- a/Data/GozbaDbContext.cs
+++ b/Data/GozbaDbContext.cs
@@ -25,6 +25,8 @@ namespace gozba_na_klik.Data
         public DbSet<Order> Orders { get; set; }
         public DbSet<OrderItem> OrderItems { get; set; }
 
+        public DbSet<UserToken> UserTokens { get; set; }
+
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/Dtos/ResetConfirmDto.cs
+++ b/Dtos/ResetConfirmDto.cs
@@ -1,0 +1,9 @@
+﻿namespace gozba_na_klik.Dtos
+{
+    public class ResetConfirmDto
+    {
+        public string Token {  get; set; }
+
+        public string NewPassword { get; set; }
+    }
+}

--- a/Dtos/ResetRequestDto.cs
+++ b/Dtos/ResetRequestDto.cs
@@ -1,0 +1,7 @@
+﻿namespace gozba_na_klik.Dtos
+{
+    public class ResetRequestDto
+    {
+        public string Email { get; set; }
+    }
+}

--- a/Migrations/20251121132738_AddUserTokenIsActive.Designer.cs
+++ b/Migrations/20251121132738_AddUserTokenIsActive.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using gozba_na_klik.Data;
@@ -11,9 +12,11 @@ using gozba_na_klik.Data;
 namespace gozba_na_klik.Migrations
 {
     [DbContext(typeof(GozbaDbContext))]
-    partial class GozbaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251121132738_AddUserTokenIsActive")]
+    partial class AddUserTokenIsActive
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20251121132738_AddUserTokenIsActive.cs
+++ b/Migrations/20251121132738_AddUserTokenIsActive.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace gozba_na_klik.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserTokenIsActive : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 3);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsActive",
+                table: "Users",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AlterColumn<TimeSpan>(
+                name: "Open",
+                table: "RestaurantWorkTimes",
+                type: "interval",
+                nullable: false,
+                defaultValue: new TimeSpan(0, 0, 0, 0, 0),
+                oldClrType: typeof(TimeSpan),
+                oldType: "interval",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<TimeSpan>(
+                name: "Close",
+                table: "RestaurantWorkTimes",
+                type: "interval",
+                nullable: false,
+                defaultValue: new TimeSpan(0, 0, 0, 0, 0),
+                oldClrType: typeof(TimeSpan),
+                oldType: "interval",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsActive",
+                table: "Users");
+
+            migrationBuilder.AlterColumn<TimeSpan>(
+                name: "Open",
+                table: "RestaurantWorkTimes",
+                type: "interval",
+                nullable: true,
+                oldClrType: typeof(TimeSpan),
+                oldType: "interval");
+
+            migrationBuilder.AlterColumn<TimeSpan>(
+                name: "Close",
+                table: "RestaurantWorkTimes",
+                type: "interval",
+                nullable: true,
+                oldClrType: typeof(TimeSpan),
+                oldType: "interval");
+
+            migrationBuilder.InsertData(
+                table: "Users",
+                columns: new[] { "Id", "Email", "FirstName", "LastName", "PasswordHash", "ProfilePicture", "Role", "Username" },
+                values: new object[,]
+                {
+                    { 1, "admin1@gozba.com", "Admin", "One", "$2a$11$VdTkF.NE1aw8uZmfFO51OuxlW9qrvbx7W8g3iKw6aHcuC1vHfMJt6\r\n", null, "Admin", "Admin1" },
+                    { 2, "admin2@gozba.com", "Admin", "Two", "$2a$11$VdTkF.NE1aw8uZmfFO51OuxlW9qrvbx7W8g3iKw6aHcuC1vHfMJt6\r\n", null, "Admin", "Admin2" },
+                    { 3, "admin3@gozba.com", "Admin", "Three", "$2a$11$VdTkF.NE1aw8uZmfFO51OuxlW9qrvbx7W8g3iKw6aHcuC1vHfMJt6\r\n", null, "Admin", "Admin3" }
+                });
+        }
+    }
+}

--- a/Migrations/20251129081316_AddUserTokenAndIsActive.Designer.cs
+++ b/Migrations/20251129081316_AddUserTokenAndIsActive.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using gozba_na_klik.Data;
@@ -11,9 +12,11 @@ using gozba_na_klik.Data;
 namespace gozba_na_klik.Migrations
 {
     [DbContext(typeof(GozbaDbContext))]
-    partial class GozbaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251129081316_AddUserTokenAndIsActive")]
+    partial class AddUserTokenAndIsActive
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20251129081316_AddUserTokenAndIsActive.cs
+++ b/Migrations/20251129081316_AddUserTokenAndIsActive.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace gozba_na_klik.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserTokenAndIsActive : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserTokens",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<int>(type: "integer", nullable: false),
+                    TokenHash = table.Column<string>(type: "text", nullable: false),
+                    Type = table.Column<int>(type: "integer", nullable: false),
+                    ExpiresAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UsedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserTokens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserTokens_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserTokens_UserId",
+                table: "UserTokens",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserTokens");
+        }
+    }
+}

--- a/Model/User.cs
+++ b/Model/User.cs
@@ -15,6 +15,8 @@ namespace gozba_na_klik.Model
 
         public string? ProfilePicture { get; set; }
 
+        public bool IsActive { get; set; } = false;
+
         public ICollection<Address>? Addresses { get; set; }
         public ICollection<UserAllergen> UserAllergens { get; set; } = new List<UserAllergen>();
         public ICollection<WorkTime>? WorkTimes { get; set; }

--- a/Model/UserToken.cs
+++ b/Model/UserToken.cs
@@ -1,0 +1,22 @@
+﻿namespace gozba_na_klik.Model
+{
+    public enum UserTokenType
+    {
+        Activation = 1,
+        ResetPassword = 2
+    }
+
+    public class UserToken
+    {
+        public int Id { get; set; }
+        public int UserId { get; set; }
+        public User User { get; set; }
+
+        public string TokenHash { get; set; }
+        public UserTokenType Type { get; set; }
+
+        public DateTime ExpiresAt { get; set; }
+        public DateTime? UsedAt { get; set; }
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -4,6 +4,7 @@ using gozba_na_klik.Middlewear;
 using gozba_na_klik.Model;
 using gozba_na_klik.Repository;
 using gozba_na_klik.Service;
+using gozba_na_klik.Service.External;
 using gozba_na_klik.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Http.Features;
@@ -73,6 +74,9 @@ namespace gozba_na_klik
             builder.Services.AddScoped<AllergenRepository>();
             builder.Services.AddScoped<UserAllergenRepository>();
             builder.Services.AddScoped<UserAllergenService>();
+            builder.Services.AddScoped<UserTokenService>();
+            builder.Services.AddScoped<IEmailService, EmailService>();
+            builder.Services.AddScoped<UserTokenRepository>();
 
             //Vukasin
             builder.Services.AddScoped<RestaurantRepository>();

--- a/Repository/UserRepository.cs
+++ b/Repository/UserRepository.cs
@@ -98,6 +98,12 @@ namespace gozba_na_klik.Repository
                 .AsNoTracking()
                 .ToListAsync();
         }
+
+        public async Task SaveChangesAsync()
+        {
+            await _dbContext.SaveChangesAsync();
+        }
+
         #endregion
     }
 }

--- a/Repository/UserTokenRepository.cs
+++ b/Repository/UserTokenRepository.cs
@@ -1,0 +1,36 @@
+﻿using gozba_na_klik.Data;
+using gozba_na_klik.Model;
+namespace gozba_na_klik.Repository
+{
+    public class UserTokenRepository
+    {
+        private readonly GozbaDbContext _context;
+        public UserTokenRepository(GozbaDbContext context)
+        {
+            _context = context;
+        }
+        public async Task<UserToken> CreateAsync(UserToken token)
+        {
+            _context.UserTokens.Add(token);
+            await _context.SaveChangesAsync();
+            return token;
+        }
+
+        public async Task<UserToken?> GetValidTokenAsync(string tokenHash, UserTokenType type)
+        {
+            return await _context.UserTokens
+                .Include(t => t.User)
+                .Where(t => t.TokenHash == tokenHash &&
+                            t.Type == type &&
+                            t.UsedAt == null &&
+                            t.ExpiresAt > DateTime.UtcNow)
+                .FirstOrDefaultAsync();
+        }
+
+        public async Task SaveChangesAsync()
+        {
+            await _context.SaveChangesAsync();
+        }
+
+    }
+}

--- a/Repository/UserTokenRepository.cs
+++ b/Repository/UserTokenRepository.cs
@@ -1,5 +1,6 @@
 ﻿using gozba_na_klik.Data;
 using gozba_na_klik.Model;
+using Microsoft.EntityFrameworkCore;
 namespace gozba_na_klik.Repository
 {
     public class UserTokenRepository

--- a/Service/AuthService.cs
+++ b/Service/AuthService.cs
@@ -4,6 +4,7 @@ using gozba_na_klik.Dtos;
 using gozba_na_klik.DtosAdmin;
 using gozba_na_klik.Model;
 using gozba_na_klik.Repository;
+using gozba_na_klik.Service.External;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using System.Reflection.Metadata.Ecma335;
@@ -15,12 +16,18 @@ namespace gozba_na_klik.Service
         private readonly UserRepository _userRepo;
         private readonly IMapper _mapper;
         private readonly ILogger<AuthService> _logger;
+        private readonly UserTokenService _tokenService;
+        private readonly IEmailService _emailService;
+        private readonly IConfiguration _config;
 
-        public AuthService(UserRepository userRepo, IMapper mapper, ILogger<AuthService> logger)
+        public AuthService(UserRepository userRepo, IMapper mapper, ILogger<AuthService> logger, UserTokenService tokenService, IEmailService emailService, IConfiguration config)
         {
             _userRepo = userRepo;
             _mapper = mapper;
             _logger = logger;
+            _tokenService = tokenService;
+            _emailService = emailService;
+            _config = config;
         }
 
         public async Task<UserDto?> LoginAsync(LoginDto dto)
@@ -30,6 +37,12 @@ namespace gozba_na_klik.Service
 
             if (user == null)
                 return null;
+
+            if (!user.IsActive)
+            {
+                _logger.LogWarning("Login attempt for inactive user {UserId}.", user.Id);
+                return null;
+            }
 
             var isValid = BCrypt.Net.BCrypt.Verify(dto.Password, user.PasswordHash);
             if (!isValid)
@@ -45,12 +58,85 @@ namespace gozba_na_klik.Service
         {
             u.PasswordHash = BCrypt.Net.BCrypt.HashPassword(rawPassword);
 
+            u.IsActive = false;
+
             var user = await _userRepo.CreateAsync(u);
 
             _logger.LogInformation("User {UserId} registered.", user.Id);
 
+            var activationToken = await _tokenService.CreateActivationToken(user.Id);
+
+            var frontendUrl = _config["FrontendUrl"] ?? "http://localhost:5173";
+
+            var activationLink = $"{frontendUrl}/activate?Token={activationToken.TokenHash}";
+
+            await _emailService.SendActivationEmailAsync(user.Email, activationLink);
+
+            _logger.LogInformation("Activation email sent to {Email}.", user.Email);
+
             return user;
         }
         public Task LogoutAsync() => Task.CompletedTask;
+
+        public async Task ActivateAsync(string tokenRaw)
+        {
+            var token = await _tokenService.ValidateToken(tokenRaw, UserTokenType.Activation);
+
+            if (token == null)
+            {
+                _logger.LogWarning("Invalid or expired activation token used.");
+                throw new Exception("Nevalidan ili istekao token za aktivaciju.");
+            }
+
+            token.User.IsActive = true;
+            token.UsedAt = DateTime.UtcNow;
+
+            await _userRepo.SaveChangesAsync();
+            _logger.LogInformation("User {UserId} activated account.", token.UserId);
+        }
+
+        public async Task RequestPasswordResetAsync(string email)
+        {
+            var normalizedEmail = (email ?? "").Trim().ToLowerInvariant();
+            var user = await _userRepo.GetByEmailAsync(normalizedEmail);
+
+            if (user == null || !user.IsActive)
+            {
+                _logger.LogWarning("Password reset requested for non-existing or inactive account {Email}.", normalizedEmail);
+                return;
+            }
+
+            var resetToken = await _tokenService.CreateResetPasswordToken(user.Id);
+
+            var frontendUrl = _config["FrontendUrl"] ?? "http://localhost:5173";
+            var resetLink = $"{frontendUrl}/reset-password?token={resetToken.TokenHash}";
+
+            await _emailService.SendResetEmailAsync(user.Email, resetLink);
+
+            _logger.LogInformation("Password reset email sent to {Email}.", user.Email);
+        }
+
+        public async Task ResetPasswordAsync(string rawToken, string newPassword)
+        {
+            var token = await _tokenService.ValidateToken(rawToken, UserTokenType.ResetPassword);
+
+            if (token == null)
+            {
+                _logger.LogWarning("Invalid or expired reset password token used.");
+                throw new Exception("Nevalidan ili istekao token za reset lozinke.");
+            }
+
+            var user = token.User;
+
+            user.PasswordHash = BCrypt.Net.BCrypt.HashPassword(newPassword);
+            token.UsedAt = DateTime.UtcNow;
+
+            await _userRepo.SaveChangesAsync();
+
+            _logger.LogInformation("User {UserId} successfully reset password.", user.Id);
+        }
+
+
+
     }
 }

--- a/Service/External/EmailService.cs
+++ b/Service/External/EmailService.cs
@@ -1,0 +1,19 @@
+﻿namespace gozba_na_klik.Service.External
+{
+    public class EmailService : IEmailService
+    {
+        public Task SendActivationEmailAsync(string to, string link)
+        {
+            Console.WriteLine($"[EMAIL] Activation link for {to}: {link}");
+            return Task.CompletedTask;
+        }
+
+        public Task SendResetEmailAsync(string to, string link)
+        {
+            {
+                Console.WriteLine($"[EMAIL] Reset link for {to}: {link}");
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/Service/External/IEmailService.cs
+++ b/Service/External/IEmailService.cs
@@ -1,0 +1,8 @@
+﻿namespace gozba_na_klik.Service.External
+{
+    public interface IEmailService
+    {
+        Task SendActivationEmailAsync(string to, string link);
+        Task SendResetEmailAsync(string to, string link);
+    }
+}

--- a/Service/IAuthService.cs
+++ b/Service/IAuthService.cs
@@ -10,6 +10,13 @@ namespace gozba_na_klik.Service
         Task<User?> GetByEmailAsync(string email);
         Task<User?> RegisterUserAsync(User user, string rawPassword);
         Task LogoutAsync();
+
+        Task ActivateAsync(string tokenRaw);
+
+        Task RequestPasswordResetAsync(string email);
+
+        Task ResetPasswordAsync(string rawToken, string newPassword);
+         
     }
 }
 

--- a/Service/IAuthService.cs
+++ b/Service/IAuthService.cs
@@ -16,7 +16,9 @@ namespace gozba_na_klik.Service
         Task RequestPasswordResetAsync(string email);
 
         Task ResetPasswordAsync(string rawToken, string newPassword);
-         
+
+        Task<string?> RequestPasswordResetAndReturnToken(string email);
+
     }
 }
 

--- a/Service/UserTokenService.cs
+++ b/Service/UserTokenService.cs
@@ -1,0 +1,24 @@
+﻿using gozba_na_klik.Model;
+using gozba_na_klik.Repository;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.WebUtilities;
+
+
+namespace gozba_na_klik.Service
+{
+    public class UserTokenService
+    {
+        private readonly UserTokenRepository _repo;
+
+        public UserTokenService(UserTokenRepository repo)
+        {
+            _repo = repo;
+        }
+
+        public string GenerateRawToken()
+        {
+            return Guid.NewGuid().ToString("N");
+        }
+    }
+}

--- a/Service/UserTokenService.cs
+++ b/Service/UserTokenService.cs
@@ -20,5 +20,68 @@ namespace gozba_na_klik.Service
         {
             return Guid.NewGuid().ToString("N");
         }
+
+        public string HashToken(string raw)
+        {
+            return raw;
+        }
+
+        public async Task<UserToken> CreateActivationToken(int userId)
+        {
+            var raw = GenerateRawToken();
+            var hash = HashToken(raw);
+
+            var token = new UserToken
+            {
+                UserId = userId,
+                Type = UserTokenType.Activation,
+                TokenHash = hash,
+                ExpiresAt = DateTime.UtcNow.AddHours(24)
+            };
+
+            await _repo.CreateAsync(token);
+
+            return new UserToken
+            {
+                Id = token.Id,
+                UserId = token.UserId,
+                TokenHash = raw,
+                Type = token.Type,
+                ExpiresAt = token.ExpiresAt,
+                CreatedAt = token.CreatedAt
+            };
+        }
+
+        public async Task<UserToken> CreateResetPasswordToken(int userId)
+        {
+            var raw = GenerateRawToken();
+            var hash = HashToken(raw);
+
+            var token = new UserToken
+            {
+                UserId = userId,
+                Type = UserTokenType.ResetPassword,
+                TokenHash = hash,
+                ExpiresAt = DateTime.UtcNow.AddHours(1)
+            };
+
+            await _repo.CreateAsync(token);
+
+            return new UserToken
+            {
+                Id = token.Id,
+                UserId = token.UserId,
+                TokenHash = raw,
+                Type = token.Type,
+                ExpiresAt = token.ExpiresAt,
+                CreatedAt = token.CreatedAt
+            };
+        }
+
+        public async Task<UserToken?> ValidateToken(string raw, UserTokenType type)
+        {
+            var hash = HashToken(raw);
+            return await _repo.GetValidTokenAsync(hash, type);
+        }
     }
 }

--- a/_Controllers/AuthController.cs
+++ b/_Controllers/AuthController.cs
@@ -174,4 +174,28 @@ public class AuthController : ControllerBase
         return Ok(new { token = tokenString });
     }
 
+    // Aktiviranje i resetovanje naloga
+
+    [HttpGet("activate")]
+    public async Task<IActionResult> Activate([FromQuery] string token)
+    {
+        await _authService.ActivateAsync(token);
+        return Ok(new {message = "Account activated. You can now log in."});
+    }
+
+    [HttpPost("reset/request")]
+    public async Task<IActionResult> RequestReset([FromBody] ResetRequestDto dto)
+    {
+        await _authService.RequestPasswordResetAsync(dto.Email);
+        return Ok(new { message = "If the account exists, reset email was sent." });
+    }
+
+    [HttpPost("reset/confirm")]
+    public async Task<IActionResult> ConfirmReset([FromBody] ResetConfirmDto dto)
+    {
+        await _authService.ResetPasswordAsync(dto.Token, dto.NewPassword);
+        return Ok(new { message = "Password has been reset. You can now log in." });
+    }
+
+
 }

--- a/_Controllers/AuthController.cs
+++ b/_Controllers/AuthController.cs
@@ -186,9 +186,15 @@ public class AuthController : ControllerBase
     [HttpPost("reset/request")]
     public async Task<IActionResult> RequestReset([FromBody] ResetRequestDto dto)
     {
-        await _authService.RequestPasswordResetAsync(dto.Email);
-        return Ok(new { message = "If the account exists, reset email was sent." });
+        var token = await _authService.RequestPasswordResetAndReturnToken(dto.Email);
+
+        return Ok(new
+        {
+            message = "If the account exists, reset email was sent.",
+            token
+        });
     }
+
 
     [HttpPost("reset/confirm")]
     public async Task<IActionResult> ConfirmReset([FromBody] ResetConfirmDto dto)

--- a/appsettings.json
+++ b/appsettings.json
@@ -27,10 +27,11 @@
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Port=5432;Database=GozbaDbContext;Username=postgres;Password=root"
   },
-  "Jwt": {
-    "Key": "pWZx6N2QJg9C0rYf3LkT1uV5a8B2mH4qR7sX0nD3cF6jK9pL2tW5yZ8uC1vE4rT7",
-    "Issuer": "GozbaApi",
-    "Audience": "GozbaClient"
-  }
+    "Jwt": {
+        "Key": "pWZx6N2QJg9C0rYf3LkT1uV5a8B2mH4qR7sX0nD3cF6jK9pL2tW5yZ8uC1vE4rT7",
+        "Issuer": "GozbaApi",
+        "Audience": "GozbaClient"
+    },
+  "FrontendUrl" :  "http://localhost:5173"
 
 }


### PR DESCRIPTION
Sta je uradjeno:

Dodata tabela i model UserToken (Activation, ResetPassword)

Prosiren AuthService da radi:

login samo za aktivne naloge (IsActive = true)

registracija sada kreira neaktivan nalog (IsActive = false)

kreiranje activation tokena i slanje activation linka na email (simulate)

aktivacija naloga preko /auth/activate?token=...

slanje reset password linka preko /auth/reset/request

potvrda nove lozinke preko /auth/reset/confirm

Dodat UserTokenService (GenerateRawToken, CreateActivationToken, CreateResetPasswordToken, ValidateToken)

Dodat UserTokenRepository (CreateAsync, GetValidTokenAsync, SaveChangesAsync)

AuthController prosiren sa:

GET /auth/activate

POST /auth/reset/request

POST /auth/reset/confirm

Login vraca JWT token + user dto samo ako je nalog aktivan

Kako testirati:

Registracija + aktivacija

POST /auth/register

U bazi Users.IsActive = false za novog user-a

U bazi UserTokens kreira se red Type = Activation (npr. 0)

GET /auth/activate?token=RAW_TOKEN (iz baze ili iz loga)

Users.IsActive = true, token UsedAt popunjen

Login

Pre aktivacije: login ne prolazi (Unauthorized)

Posle aktivacije: login prolazi, vraca JWT + user dto

Reset password request

POST /auth/reset/request sa email-om aktivnog naloga

U UserTokens novi red sa Type = ResetPassword (npr. 1 ili 2) i UsedAt = null

Za nepostojeci ili neaktivan nalog: vraca 200 ali se ne pravi novi token

Reset password confirm

POST /auth/reset/confirm sa:

token = TokenHash iz poslednjeg ResetPassword reda

newPassword = nova lozinka

Ocekivano: 200 OK, Users.PasswordHash promenjen, UserTokens.UsedAt popunjen

Provera login posle reseta

Login sa starom lozinkom: ne prolazi

Login sa novom lozinkom: prolazi

Ponovno koriscenje istog reset tokena

Ponovo POST /auth/reset/confirm sa istim tokenom

Ocekivano: greska "Nevalidan ili istekao token za reset lozinke."